### PR TITLE
Add highlights and note fields to app manager tables and update Fails…

### DIFF
--- a/migrations/2022_05_20_113232_create_app_manager_tables.php
+++ b/migrations/2022_05_20_113232_create_app_manager_tables.php
@@ -42,7 +42,7 @@ class CreateAppManagerTables extends Migration
 			$table->boolean('choose_later_plan')->nullable();
 			$table->text('affiliate')->nullable();
 			$table->text('feature_plan')->nullable();
-			$table->text('highlights')->nullable();
+			$table->text('details')->nullable();
             $table->boolean('is_external_charge')->default(false);
             $table->integer('external_charge_limit')->default(10000);
             $table->string('terms')->nullable();

--- a/migrations/2022_05_20_113232_create_app_manager_tables.php
+++ b/migrations/2022_05_20_113232_create_app_manager_tables.php
@@ -26,6 +26,7 @@ class CreateAppManagerTables extends Migration
 			$table->double('price', 8, 2);
 			$table->string('offer_text')->nullable();
 			$table->string('description')->nullable();
+			$table->string('note')->nullable();
 			$table->text('interval');
 			$table->text('shopify_plans')->nullable();
 			$table->integer('trial_days')->default(0);
@@ -41,6 +42,7 @@ class CreateAppManagerTables extends Migration
 			$table->boolean('choose_later_plan')->nullable();
 			$table->text('affiliate')->nullable();
 			$table->text('feature_plan')->nullable();
+			$table->text('highlights')->nullable();
             $table->boolean('is_external_charge')->default(false);
             $table->integer('external_charge_limit')->default(10000);
             $table->string('terms')->nullable();

--- a/src/app/Http/Controllers/ChargeController.php
+++ b/src/app/Http/Controllers/ChargeController.php
@@ -97,10 +97,12 @@ class ChargeController extends Controller
                 if($remaining !== null){
                     if($shop->$storePlanField != null){
                         $currentPlan = \AppManager::getPlan($shop->$storePlanField);
-                        $usedDays = $currentPlan['trial_days'] - $remaining;
-                        if($usedDays > 0){
-                            $days = $trialDays - $usedDays;
-                            $trialDays = $days > 0?$days:0;
+                        if (!empty($currentPlan) && !empty($currentPlan['trial_days'])) {
+                            $usedDays = $currentPlan['trial_days'] - $remaining;
+                            if ($usedDays > 0) {
+                                $days = $trialDays - $usedDays;
+                                $trialDays = $days > 0 ? $days : 0;
+                            }
                         }
                     }else{
                         $trialDays = $remaining;

--- a/src/app/Traits/FailsafeHelper.php
+++ b/src/app/Traits/FailsafeHelper.php
@@ -70,8 +70,7 @@ trait FailsafeHelper {
             $featuresByPlans = collect($featuresByPlans)->groupBy('plan_id')->toArray();
         }
 
-        $planIds = collect($plans)->pluck('id')->toArray();
-        $detailsByPlans = !empty($planIds)
+        $detailsByPlans = !empty($plans)
             ? collect($plans)->pluck('details', 'id')
                 ->map(function ($details) {
                     return json_decode($details, true) ?? [];

--- a/src/app/Traits/FailsafeHelper.php
+++ b/src/app/Traits/FailsafeHelper.php
@@ -72,12 +72,10 @@ trait FailsafeHelper {
 
         $planIds = collect($plans)->pluck('id')->toArray();
         $highlightsByPlans = !empty($planIds)
-            ? DB::connection('app-manager-failsafe')->table('plan_highlights')
-                ->whereIn('plan_id', $planIds)
-                ->orderBy('sort_order')
-                ->get()
-                ->groupBy('plan_id')
-                ->toArray()
+            ? collect($plans)->pluck('highlights', 'id')
+                ->map(function ($highlights) {
+                    return json_decode($highlights, true) ?? [];
+                })->toArray()
             : [];
 
         $customDiscounts = DB::connection('app-manager-failsafe')->table('discount_plan')->where('shop_domain', $shop_domain)
@@ -97,18 +95,18 @@ trait FailsafeHelper {
             $plans[$key]['interval'] = json_decode($plan['interval'], true)['value'];
             $plans[$key]['shopify_plans'] = collect(json_decode($plan['shopify_plans'], true))->pluck('value')->toArray();
             $plans[$key]['features'] = isset($featuresByPlans[$plan['id']]) ? collect($featuresByPlans[$plan['id']])->keyBy('feature_id')->toArray() : null;
-            $plans[$key]['highlights'] = isset($highlightsByPlans[$plan['id']]) ? $highlightsByPlans[$plan['id']]->values()->toArray() : [];;
+            $plans[$key]['highlights'] = $highlightsByPlans[$plan['id']] ?? [];;
             $index = isset($customDiscounts[$plan['id']]) ? $plan['id'] : (isset($customDiscounts[-1]) ? -1 : null);
             if ($index) {
                 $plans[$key]['discount'] = $customDiscounts[$index]['discount'];
                 $plans[$key]['discount_type'] = $customDiscounts[$index]['discount_type'];
                 $plans[$key]['cycle_count'] = $customDiscounts[$index]['cycle_count'];
             }
+
+            $plans[$key]['fail_safe_response'] = true;
         }
 
-        $plans = $this->filterPlansByShopifyPlan($plans, $shopify_plan, $customPlanIds);
-
-        return $plans;
+        return $this->filterPlansByShopifyPlan($plans, $shopify_plan, $customPlanIds);
     }
 
     public function preparePlan($data) {

--- a/src/app/Traits/FailsafeHelper.php
+++ b/src/app/Traits/FailsafeHelper.php
@@ -70,6 +70,16 @@ trait FailsafeHelper {
             $featuresByPlans = collect($featuresByPlans)->groupBy('plan_id')->toArray();
         }
 
+        $planIds = collect($plans)->pluck('id')->toArray();
+        $highlightsByPlans = !empty($planIds)
+            ? DB::connection('app-manager-failsafe')->table('plan_highlights')
+                ->whereIn('plan_id', $planIds)
+                ->orderBy('sort_order')
+                ->get()
+                ->groupBy('plan_id')
+                ->toArray()
+            : [];
+
         $customDiscounts = DB::connection('app-manager-failsafe')->table('discount_plan')->where('shop_domain', $shop_domain)
             ->orderByDesc('created_at')->get(['plan_id','discount', 'discount_type', 'cycle_count'])->first();
         if ($customDiscounts) {
@@ -87,6 +97,7 @@ trait FailsafeHelper {
             $plans[$key]['interval'] = json_decode($plan['interval'], true)['value'];
             $plans[$key]['shopify_plans'] = collect(json_decode($plan['shopify_plans'], true))->pluck('value')->toArray();
             $plans[$key]['features'] = isset($featuresByPlans[$plan['id']]) ? collect($featuresByPlans[$plan['id']])->keyBy('feature_id')->toArray() : null;
+            $plans[$key]['highlights'] = isset($highlightsByPlans[$plan['id']]) ? $highlightsByPlans[$plan['id']]->values()->toArray() : [];;
             $index = isset($customDiscounts[$plan['id']]) ? $plan['id'] : (isset($customDiscounts[-1]) ? -1 : null);
             if ($index) {
                 $plans[$key]['discount'] = $customDiscounts[$index]['discount'];
@@ -394,7 +405,7 @@ trait FailsafeHelper {
 
     public function unSerializeData ($data) {
         foreach ($data as $index => $datum) {
-            if (in_array($index, ['interval', 'shopify_plans', 'affiliate', 'features'])) {
+            if (in_array($index, ['interval', 'shopify_plans', 'affiliate', 'features', 'highlights'])) {
                 $data[$index] = json_decode($datum, true);
             }
         }

--- a/src/app/Traits/FailsafeHelper.php
+++ b/src/app/Traits/FailsafeHelper.php
@@ -71,10 +71,10 @@ trait FailsafeHelper {
         }
 
         $planIds = collect($plans)->pluck('id')->toArray();
-        $highlightsByPlans = !empty($planIds)
-            ? collect($plans)->pluck('highlights', 'id')
-                ->map(function ($highlights) {
-                    return json_decode($highlights, true) ?? [];
+        $detailsByPlans = !empty($planIds)
+            ? collect($plans)->pluck('details', 'id')
+                ->map(function ($details) {
+                    return json_decode($details, true) ?? [];
                 })->toArray()
             : [];
 
@@ -95,7 +95,7 @@ trait FailsafeHelper {
             $plans[$key]['interval'] = json_decode($plan['interval'], true)['value'];
             $plans[$key]['shopify_plans'] = collect(json_decode($plan['shopify_plans'], true))->pluck('value')->toArray();
             $plans[$key]['features'] = isset($featuresByPlans[$plan['id']]) ? collect($featuresByPlans[$plan['id']])->keyBy('feature_id')->toArray() : null;
-            $plans[$key]['highlights'] = $highlightsByPlans[$plan['id']] ?? [];;
+            $plans[$key]['details'] = $detailsByPlans[$plan['id']] ?? [];;
             $index = isset($customDiscounts[$plan['id']]) ? $plan['id'] : (isset($customDiscounts[-1]) ? -1 : null);
             if ($index) {
                 $plans[$key]['discount'] = $customDiscounts[$index]['discount'];
@@ -403,7 +403,7 @@ trait FailsafeHelper {
 
     public function unSerializeData ($data) {
         foreach ($data as $index => $datum) {
-            if (in_array($index, ['interval', 'shopify_plans', 'affiliate', 'features', 'highlights'])) {
+            if (in_array($index, ['interval', 'shopify_plans', 'affiliate', 'features', 'details'])) {
                 $data[$index] = json_decode($datum, true);
             }
         }


### PR DESCRIPTION
This pull request introduces enhancements to the app manager's plan management functionality, focusing on adding support for plan highlights, improving plan data serialization, and refining trial day calculations. The changes update both the database schema and backend logic to handle new plan attributes and ensure accurate plan processing.

**Database schema updates:**

* Added a nullable `note` string column and a nullable `highlights` text column to the plans table in the migration file, enabling storage of additional plan information and highlights. [[1]](diffhunk://#diff-1b9e3010c2a8b013987b01a4cb7fa6dd54bac9541f7b0e6f16ec7871d72be774R29) [[2]](diffhunk://#diff-1b9e3010c2a8b013987b01a4cb7fa6dd54bac9541f7b0e6f16ec7871d72be774R45)

**Plan data handling enhancements:**

* Updated the `preparePlans` method in `FailsafeHelper` to extract and decode the new `highlights` field for each plan, making highlights available in the plan data structure. [[1]](diffhunk://#diff-1c589d5430e84288b5516f08e910f7031f8ee9440e44d3ea1323b9323b64afa8R73-R80) [[2]](diffhunk://#diff-1c589d5430e84288b5516f08e910f7031f8ee9440e44d3ea1323b9323b64afa8R98-R109)
* Modified the `unSerializeData` method to include `highlights` in the list of fields to be JSON-decoded, ensuring consistent data handling for this new field.

**Business logic improvements:**

* Improved trial day calculation in `ChargeController` to only adjust remaining trial days if the current plan and its `trial_days` attribute are present, preventing potential errors when these values are missing.