### PR TITLE
Mgr 72

### DIFF
--- a/migrations/2022_05_20_113232_create_app_manager_tables.php
+++ b/migrations/2022_05_20_113232_create_app_manager_tables.php
@@ -30,11 +30,14 @@ class CreateAppManagerTables extends Migration
 			$table->text('interval');
 			$table->text('shopify_plans')->nullable();
 			$table->integer('trial_days')->default(0);
+            $table->text('trial_days_text')->nullable();
 			$table->integer('test')->nullable();
 			$table->dateTime('on_install')->nullable();
 			$table->boolean('is_custom')->default(false);
 			$table->unsignedBigInteger('base_plan')->nullable();
 			$table->boolean('public')->default(true);
+            $table->boolean('most_popular')->default(false);
+            $table->text('plan_badge')->nullable();
 			$table->integer('discount')->nullable();
 			$table->smallInteger('cycle_count')->nullable();
 			$table->enum('discount_type', ['amount', 'percentage'])->nullable();
@@ -147,6 +150,14 @@ class CreateAppManagerTables extends Migration
             $table->json('shopify_plans');
             $table->timestamps();
         });
+
+        Schema::create('app_faqs', function (Blueprint $table) {
+            $table->id();
+            $table->text('question');
+            $table->longText('answer');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+        });
     }
 
 	/**
@@ -167,5 +178,6 @@ class CreateAppManagerTables extends Migration
 		Schema::dropIfExists('discounts_usage_log');
 		Schema::dropIfExists('discount_plans');
 		Schema::dropIfExists('app_filters');
+		Schema::dropIfExists('app_faqs');
 	}
 }

--- a/src/AppManager.php
+++ b/src/AppManager.php
@@ -53,6 +53,20 @@ class AppManager
         }
     }
 
+    public function getAppFaqs() {
+
+        try {
+            $data = $this->client->get('app-faqs');
+            return (Str::startsWith($data->getStatusCode(), '2') || (Str::startsWith($data->getStatusCode(), '4') && $data->getStatusCode() != 429))
+                ? $data->json()
+                : $this->prepareAppFaqs();
+        }
+        catch (\Exception $e) {
+            report($e);
+            return $this->prepareAppFaqs();
+        }
+    }
+
     public function getPlan($plan_id, $shop_domain = null) {
 
         try {

--- a/src/app/Http/Controllers/PlanController.php
+++ b/src/app/Http/Controllers/PlanController.php
@@ -47,7 +47,7 @@ class PlanController extends Controller
         $cacheKey = $request->has('shop_domain') ? 'app-manager.plans-'.$request->get('shop_domain') : 'app-manager.all-plans';
 
         $response = appManagerCacheData($cacheKey, function () use ($request, $shopTableName, $storeFieldName, $planFieldName, $shopifyPlanFieldName, $cacheKey, $mostPopularPlanIds, $sdkVersions) {
-            $shopify_plan = $plan = $globalPlan = $plans = $trialActivatedAt = null;
+            $shopify_plan = $plan = $globalPlan = $plans = $trialActivatedAt = $appFaqs = null;
             $choose_later = false;
 
             if ($request->has('shop_domain')) {
@@ -56,6 +56,7 @@ class PlanController extends Controller
                 $shopify_plan = collect($userData)->pluck($shopifyPlanFieldName)->first();
                 $activePlanId = collect($userData)->pluck($planFieldName)->first() ?? null;
                 $plans = \AppManager::getPlans($shopDomain, $activePlanId, $shopify_plan, $sdkVersions);
+                $appFaqs = \AppManager::getAppFaqs();
                 $plan = collect($plans)->where('id', $activePlanId)->first();
                 $trialActivatedAt = collect($userData)->pluck(config('app-manager.field_names.trial_activated_at', 'trial_activated_at'))->first() ?? null;
                 $activeCharge = \AppManager::getCharge($shopDomain);
@@ -100,6 +101,7 @@ class PlanController extends Controller
 
             return [
                 'plans' => $plans,
+                'app_faqs' => $appFaqs,
                 'promotional_discount' => $promotionalDiscount,
                 'shopify_plan' => $shopify_plan,
                 'plan' => $plan,
@@ -309,6 +311,14 @@ class PlanController extends Controller
                 }
                 break;
 
+            case 'app-faqs':
+                DB::connection('app-manager-failsafe')->table('app_faqs')->truncate();
+                $filteredFaqs = $this->filterData($payload, $dateFields, ['pivot']);
+                foreach ($filteredFaqs as $faq) {
+                    DB::connection('app-manager-failsafe')->table('app_faqs')->insert($faq);
+                }
+                break;
+
             default:
                 $tableMap = [
                     'plan-discount' => 'discount_plan',
@@ -397,6 +407,8 @@ class PlanController extends Controller
         }
         $this->batchInsert('app_filters', $appFilters);
 
+        $appFaqs = $this->filterDataForFullFailsafeBackup($data['app_faqs'], $commanFields);
+        $this->batchInsert('app_faqs', $appFaqs);
     }
 
     public function filterData($data, $dateFields = [], $excludeKeys = ['app_id', 'pivot'])

--- a/src/app/Http/Controllers/PlanController.php
+++ b/src/app/Http/Controllers/PlanController.php
@@ -313,7 +313,7 @@ class PlanController extends Controller
 
             case 'app-faqs':
                 DB::connection('app-manager-failsafe')->table('app_faqs')->truncate();
-                $filteredFaqs = $this->filterData($payload, $dateFields, ['pivot']);
+                $filteredFaqs = $this->filterData($payload, $dateFields, ['pivot', 'app_id']);
                 foreach ($filteredFaqs as $faq) {
                     DB::connection('app-manager-failsafe')->table('app_faqs')->insert($faq);
                 }

--- a/src/app/Traits/FailsafeHelper.php
+++ b/src/app/Traits/FailsafeHelper.php
@@ -14,6 +14,16 @@ trait FailsafeHelper {
         return head($marketingBannersData)->marketing_banners ?? null;
     }
 
+    public function prepareAppFaqs()
+    {
+        return DB::connection('app-manager-failsafe')
+            ->table('app_faqs')
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get()
+            ->toArray();
+    }
+
     public function preparePlans($shop_domain, $active_plan_id = null, $shopify_plan = null) {
 
         $activeChargePrice = $activePlanId = null;


### PR DESCRIPTION
This pull request introduces support for managing and serving app FAQs within the app manager. It adds a new `app_faqs` table, provides methods to retrieve and back up FAQ data, and ensures FAQs are included in relevant API responses and backup routines.

**Database Schema Changes:**

* Added a new `app_faqs` table to store frequently asked questions, including fields for question, answer, sort order, and timestamps.
* Updated the `down` migration to drop the new `app_faqs` table when rolling back.
* Enhanced the `plans` table with new fields: `trial_days_text`, `most_popular`, and `plan_badge` to support richer plan metadata.

**API and Data Handling:**

* Added the `getAppFaqs` method to `AppManager` for retrieving FAQs, with fallback to a failsafe backup if the API call fails.
* Included FAQs (`app_faqs`) in the response of the `plans` API endpoint, ensuring clients receive FAQ data alongside plan details. [[1]](diffhunk://#diff-572a1cd4adf82fddfce6d0e758d99eb3c6cf30f4e59b85f6fc87ca67ea8c9374R59) [[2]](diffhunk://#diff-572a1cd4adf82fddfce6d0e758d99eb3c6cf30f4e59b85f6fc87ca67ea8c9374R104) [[3]](diffhunk://#diff-572a1cd4adf82fddfce6d0e758d99eb3c6cf30f4e59b85f6fc87ca67ea8c9374L50-R50)

**Failsafe and Backup Enhancements:**

* Implemented failsafe backup and restore logic for the new `app_faqs` table in both incremental and full backup routines, ensuring FAQ data is protected and recoverable. [[1]](diffhunk://#diff-572a1cd4adf82fddfce6d0e758d99eb3c6cf30f4e59b85f6fc87ca67ea8c9374R314-R321) [[2]](diffhunk://#diff-572a1cd4adf82fddfce6d0e758d99eb3c6cf30f4e59b85f6fc87ca67ea8c9374R410-R411) [[3]](diffhunk://#diff-1c589d5430e84288b5516f08e910f7031f8ee9440e44d3ea1323b9323b64afa8R17-R26)